### PR TITLE
Add `!r` command to auto-react to questions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "better-sqlite3": "^8.4.0",
     "crypto": "^1.0.1",
-    "discord.js": "14.11.0",
+    "discord.js": "14.16.0",
     "dotenv": "^16.3.1",
     "radash": "^11.0.0"
   },

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -11,7 +11,7 @@ import handleAuthorCommand from './handlers/authorCommandHandler';
 
 const userProgressMap = new Map<string, UserProgress>();
 
-const client = new Client({
+export const client = new Client({
     intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
@@ -41,7 +41,7 @@ client.on('messageCreate', async (message) => {
         } else if (message.content === '!category') {
             await handleCategoryCommand(message);
         } else if (message.content === '!author') {
-            await handleAuthorCommand(message);            
+            await handleAuthorCommand(message);
         } else {
             let setUserProgress = userProgressMap.set.bind(userProgressMap);
             let deleteUserProgress = userProgressMap.delete.bind(userProgressMap);

--- a/src/handlers/authorCommandHandler.ts
+++ b/src/handlers/authorCommandHandler.ts
@@ -16,7 +16,7 @@ export default async function handleAuthorCommand(message:Message<boolean>) {
             author_id: d.author_id
         }));
         const tossupTable = getTable(
-            [ 'Total', 'Total Plays', 'Conv. %', 'Neg %', 'Avg. Buzz', 'First Buzz', AUTHOR ], 
+            [ 'Total', 'Total Plays', 'Conv. %', 'Neg %', 'Avg. Buzz', 'First Buzz', AUTHOR ],
             categoryData
         );
         const bonusAuthorData = getBonusAuthorData(message.guildId!).map(d => Object.values({
@@ -29,7 +29,7 @@ export default async function handleAuthorCommand(message:Message<boolean>) {
             author_id: d.author_id
         }));
         const bonusTable = getTable(
-            [ 'Total', 'Total Plays', 'PPB', 'E%', 'M%', 'H%', AUTHOR ], 
+            [ 'Total', 'Total Plays', 'PPB', 'E%', 'M%', 'H%', AUTHOR ],
             bonusAuthorData
         );
 

--- a/src/handlers/buttonClickHandler.ts
+++ b/src/handlers/buttonClickHandler.ts
@@ -11,7 +11,7 @@ export default async function handleButtonClick(interaction: Interaction, userPr
             const bonusMatch = questionMessage.content.match(BONUS_REGEX);
             const tossupMatch = questionMessage.content.match(TOSSUP_REGEX);
             const authorName = questionMessage.member?.displayName ?? questionMessage.author.username;
-            
+
             if (userProgress.get(interaction.user.id)) {
                 await interaction.user.send(getEmbeddedMessage("You tried to start playtesting a question but have a different question reading in progress. Please complete that reading or type `x` to end it, then try again."));
             } else if (bonusMatch) {

--- a/src/handlers/categoryCommandHandler.ts
+++ b/src/handlers/categoryCommandHandler.ts
@@ -17,7 +17,7 @@ export default async function handleCategoryCommand(message:Message<boolean>) {
             category: d.category
         }));
         const tossupTable = getTable(
-            [ 'Total', 'Total Plays', 'Conv. %', 'Neg %', 'Avg. Buzz', 'First Buzz', CATEGORY ], 
+            [ 'Total', 'Total Plays', 'Conv. %', 'Neg %', 'Avg. Buzz', 'First Buzz', CATEGORY ],
             categoryData
         );
         const bonusCategoryData = getBonusCategoryData(message.guildId!).map(d => Object.values({
@@ -30,7 +30,7 @@ export default async function handleCategoryCommand(message:Message<boolean>) {
             category: d.category
         }));
         const bonusTable = getTable(
-            [ 'Total', 'Total Plays', 'PPB', 'E%', 'M%', 'H%', CATEGORY], 
+            [ 'Total', 'Total Plays', 'PPB', 'E%', 'M%', 'H%', CATEGORY],
             bonusCategoryData
         );
 

--- a/src/handlers/configHandler.ts
+++ b/src/handlers/configHandler.ts
@@ -1,22 +1,46 @@
-import { Message } from "discord.js";
+import { Message, TextChannel } from "discord.js";
 import { SECRET_ROLE } from "src/constants";
-import { saveServerChannelsFromMessage } from "src/utils";
+import { saveAsyncServerChannelsFromMessage, saveBulkServerChannelsFromMessage, deleteServerChannelsCommand } from "src/utils";
 
 export default async function handleConfig(message:Message<boolean>) {
-    await message.channel.send('Please list any channels that will be used for playtesting in a message of the format `#playtesting-channel / #playtesting-results-channel #playtesting-channel-2 / #playtesting-results-channel-2`. NOTE: multiple playtesting channels can share a playtesting-results-channel');
+    const msgChannel = ( await message.channel.fetch() as TextChannel );
+
+    await msgChannel.send('First, configure the channels used for internal, asynchronous playtesting - where the results should be saved to a separate channel.');
+    await msgChannel.send('List these channels in the form: `#playtesting-channel/#playtesting-results-channel #playtesting-channel-2/#playtesting-results-channel-2`.');
+    await msgChannel.send('Make sure to add exactly one space between each set of playtesting and results channels. Note: Multiple playtesting channels can share a `playtesting-results-channel`.');
 
     try {
         let filter = (m: Message<boolean>) => m.author.id === message.author.id
-        let collected = await message.channel.awaitMessages({
+        let collected = await msgChannel.awaitMessages({
             filter,
             max: 1
         });
 
-        saveServerChannelsFromMessage(collected, message.guild!);
+        deleteServerChannelsCommand.run(message.guild!.id);
 
-        await message.channel.send('Configuration saved successfully.');
-        await message.channel.send(`If you would like question answers and player notes to be encrypted in the bot's database, please create a role called \`${SECRET_ROLE}\`.`);
+        saveAsyncServerChannelsFromMessage(collected, message.guild!);
+
+        await msgChannel.send('Configuration saved successfully.');
+        await msgChannel.send(`If you would like question answers and player notes to be encrypted in the bot's database, please create a role called \`${SECRET_ROLE}\`.`);
+
+        await msgChannel.send('Now, list the channels used for bulk playtesting - where playtesters will use reactions to indicate their results.');
+        await msgChannel.send('List these channels in the form: `#playtesting-channel #playtesting-channel-2`.');
+        await msgChannel.send('Do not repeat any channels from asynchronous playtesting. Make sure to add exactly one space between set of playtesting channels.');
+
+        try {
+            let filter = (m: Message<boolean>) => m.author.id === message.author.id
+            let collected = await msgChannel.awaitMessages({
+                filter,
+                max: 1
+            });
+
+            saveBulkServerChannelsFromMessage(collected, message.guild!);
+
+            await msgChannel.send('Configuration saved successfully.');
+        } catch {
+            await msgChannel.send("An error occurred, please try again.");
+        }
     } catch {
-        await message.channel.send("An error occurred, please try again");
+        await msgChannel.send("An error occurred, please try again.");
     }
 }

--- a/src/handlers/newQuestionHandler.ts
+++ b/src/handlers/newQuestionHandler.ts
@@ -41,7 +41,7 @@ async function handleReacts(message:Message, isBonus: boolean) {
         if (isBonus) {
             reacts = ["bonus", "easy_part", "medium_part", "hard_part"];
         } else {
-            reacts = ["tossup", "ten_points", "zero_points"];
+            reacts = ["tossup", "ten_points", "zero_points", "neg"];
         }
         // const emojiList = emojis.map((e, x) => `${x} = ${e} | ${e.name}`).join("\n");
         // console.log(emojiList);

--- a/src/handlers/newQuestionHandler.ts
+++ b/src/handlers/newQuestionHandler.ts
@@ -68,11 +68,13 @@ export default async function handleNewQuestion(message:Message<boolean>) {
     const playtestingChannels = getServerChannels(message.guild!.id);
     const key = KeySingleton.getInstance().getKey(message);
 
-    if (playtestingChannels.find(c => c.channel_id === message.channel.id) && (bonusMatch || tossupMatch)) {
+    const msgChannel = playtestingChannels.find(c => c.channel_id === message.channel.id);
+
+    if (msgChannel && (bonusMatch || tossupMatch)) {
         let threadQuestionText = '';
         let threadMetadata = '';
 
-        if (message.content.includes('!r')) { // If we only want reacts for playtesting, don't need to create a thread and save results
+        if (msgChannel.channel_type === 2) {
             await handleReacts(message, !!bonusMatch);
         } else {
             if (bonusMatch) {

--- a/src/handlers/newQuestionHandler.ts
+++ b/src/handlers/newQuestionHandler.ts
@@ -38,6 +38,7 @@ async function handleReacts(message:Message, isBonus: boolean) {
     if (isBonus) {
 		try {
             // const alphaEmoji = (letter: string) => (String.fromCodePoint(127462 + parseInt(letter, 36) - 10));
+            await message.react("<:bonus:1311819077504733274>");
             await message.react("<:easy_part:1311811914916954243>");
             await message.react("<:medium_part:1311811928192192543>");
             await message.react("<:hard_part:1311811943727632399>");
@@ -46,6 +47,7 @@ async function handleReacts(message:Message, isBonus: boolean) {
 		}
     } else {
 		try {
+			await message.react("<:tossup:1311819091987791904>");
 			await message.react("<:ten_points:1311811889314926652>");
 			await message.react("<:zero_points:1311811903625887786>");
 		} catch (error) {

--- a/src/handlers/newQuestionHandler.ts
+++ b/src/handlers/newQuestionHandler.ts
@@ -6,31 +6,51 @@ import { buildButtonMessage, getCategoryCount, getServerChannels, getTossupParts
 const extractCategory = (metadata:string | undefined) => {
     if (!metadata)
         return "";
-    
+
     metadata = removeSpoilers(metadata);
     let results = metadata.match(/([A-Z]{2,3}), (.*)/);
 
     if (results)
         return results[2].trim();
-    
+
     results = metadata.match(/(.*), ([A-Z]{2,3})/);
 
     if (results)
         return results[1].trim();
-    
+
     return "";
 }
 
 async function handleThread(message:Message, isBonus: boolean, question:string, metadata:string) {
     if (message.content.includes('!t')) {
         const thread = await message.startThread({
-            name: metadata ? 
-                `${removeSpoilers(metadata)} - ${isBonus ? "Bonus" : "Tossup"} ${getCategoryCount(message.author.id, message.guild?.id, extractCategory(metadata), isBonus)}` 
+            name: metadata ?
+                `${removeSpoilers(metadata)} - ${isBonus ? "Bonus" : "Tossup"} ${getCategoryCount(message.author.id, message.guild?.id, extractCategory(metadata), isBonus)}`
                 : `"${question.substring(0, 30)}..."`,
             autoArchiveDuration: 60
         });
 
         thread.members.add(message.author);
+    }
+}
+
+async function handleReacts(message:Message, isBonus: boolean) {
+    if (isBonus) {
+		try {
+            // const alphaEmoji = (letter: string) => (String.fromCodePoint(127462 + parseInt(letter, 36) - 10));
+            await message.react("<:easy_part:1311811914916954243>");
+            await message.react("<:medium_part:1311811928192192543>");
+            await message.react("<:hard_part:1311811943727632399>");
+		} catch (error) {
+			console.error('One of the emojis failed to react:', error);
+		}
+    } else {
+		try {
+			await message.react("<:ten_points:1311811889314926652>");
+			await message.react("<:zero_points:1311811903625887786>");
+		} catch (error) {
+			console.error('One of the emojis failed to react:', error);
+		}
     }
 }
 
@@ -44,36 +64,40 @@ export default async function handleNewQuestion(message:Message<boolean>) {
         let threadQuestionText = '';
         let threadMetadata = '';
 
-        if (bonusMatch) {
-            const [_, __, part1, answer1, part2, answer2, part3, answer3, metadata, difficultyPart1, difficultyPart2, difficultyPart3] = bonusMatch;
-            const difficulty1Match = part1.match(BONUS_DIFFICULTY_REGEX) || [];
-            const difficulty2Match = part2.match(BONUS_DIFFICULTY_REGEX) || [];
-            const difficulty3Match = part3.match(BONUS_DIFFICULTY_REGEX) || [];
-            threadQuestionText = part1;
-            threadMetadata = metadata;
+        if (message.content.includes('!r')) { // If we only want reacts for playtesting, don't need to create a thread and save results
+            await handleReacts(message, !!bonusMatch);
+        } else {
+            if (bonusMatch) {
+                const [_, __, part1, answer1, part2, answer2, part3, answer3, metadata, difficultyPart1, difficultyPart2, difficultyPart3] = bonusMatch;
+                const difficulty1Match = part1.match(BONUS_DIFFICULTY_REGEX) || [];
+                const difficulty2Match = part2.match(BONUS_DIFFICULTY_REGEX) || [];
+                const difficulty3Match = part3.match(BONUS_DIFFICULTY_REGEX) || [];
+                threadQuestionText = part1;
+                threadMetadata = metadata;
 
-            saveBonus(message.id, message.guildId!, message.author.id, extractCategory(metadata), [
-                { part: 1, answer: shortenAnswerline(answer1), difficulty: difficultyPart1 || difficulty1Match[1] || null},
-                { part: 2, answer: shortenAnswerline(answer2), difficulty: difficultyPart2 || difficulty2Match[1] || null},
-                { part: 3, answer: shortenAnswerline(answer3), difficulty: difficultyPart3 || difficulty3Match[1] || null}
-            ], key);
-        } else if (tossupMatch) {
-            const [_, question, answer, metadata] = tossupMatch;
-            const tossupParts = getTossupParts(question);
-            const questionLength = tossupParts.reduce((a, b) => {
-                return a + b.length;
-            }, 0);
-            threadQuestionText = question;
-            threadMetadata = metadata;
+                saveBonus(message.id, message.guildId!, message.author.id, extractCategory(metadata), [
+                    { part: 1, answer: shortenAnswerline(answer1), difficulty: difficultyPart1 || difficulty1Match[1] || null},
+                    { part: 2, answer: shortenAnswerline(answer2), difficulty: difficultyPart2 || difficulty2Match[1] || null},
+                    { part: 3, answer: shortenAnswerline(answer3), difficulty: difficultyPart3 || difficulty3Match[1] || null}
+                ], key);
+            } else if (tossupMatch) {
+                const [_, question, answer, metadata] = tossupMatch;
+                const tossupParts = getTossupParts(question);
+                const questionLength = tossupParts.reduce((a, b) => {
+                    return a + b.length;
+                }, 0);
+                threadQuestionText = question;
+                threadMetadata = metadata;
 
-            // if a tossup was sent that has 2 or fewer spoiler tagged sections, assume that it's not meant to be played
-            if (tossupParts.length <= 2)
-                return;
+                // if a tossup was sent that has 2 or fewer spoiler tagged sections, assume that it's not meant to be played
+                if (tossupParts.length <= 2)
+                    return;
 
-            saveTossup(message.id, message.guildId!, message.author.id, questionLength, extractCategory(metadata), shortenAnswerline(answer), key);
+                saveTossup(message.id, message.guildId!, message.author.id, questionLength, extractCategory(metadata), shortenAnswerline(answer), key);
+            }
+
+            await message.reply(buildButtonMessage(!!bonusMatch));
+            await handleThread(message, !!bonusMatch, threadQuestionText, threadMetadata);
         }
-
-        await message.reply(buildButtonMessage(!!bonusMatch));
-        await handleThread(message, !!bonusMatch, threadQuestionText, threadMetadata);
     }
 }

--- a/src/init-schema.ts
+++ b/src/init-schema.ts
@@ -6,7 +6,8 @@ db.exec(`
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     server_id TEXT,
     channel_id TEXT,
-    result_channel_id TEXT
+    result_channel_id TEXT,
+    channel_type INT
   )
 `);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,8 +9,8 @@ import { getBonusSummaryData } from "./queries";
 
 const db = new Database('database.db');
 
-const deleteServerChannelsCommand = db.prepare('DELETE FROM server_channel WHERE server_id = ?');
-const insertServerChannelCommand = db.prepare('INSERT INTO server_channel (server_id, channel_id, result_channel_id) VALUES (?, ?, ?)');
+export const deleteServerChannelsCommand = db.prepare('DELETE FROM server_channel WHERE server_id = ?');
+const insertServerChannelCommand = db.prepare('INSERT INTO server_channel (server_id, channel_id, result_channel_id, channel_type) VALUES (?, ?, ?, ?)');
 const getServerChannelsQuery = db.prepare('SELECT * FROM server_channel WHERE server_id = ?');
 const insertBuzzCommand = db.prepare('INSERT INTO buzz (server_id, question_id, author_id, user_id, clue_index, characters_revealed, value, answer_given) VALUES (?, ?, ?, ?, ?, ?, ?, ?)');
 const insertBonusDirectCommand = db.prepare('INSERT INTO bonus_direct (server_id, question_id, author_id, user_id, part, value, answer_given) VALUES (?, ?, ?, ?, ?, ?, ?)');
@@ -35,6 +35,7 @@ export const formatDecimal = (value: number | null | undefined, fractionDigits:n
 
 export enum ServerChannelType {
     Playtesting = 1,
+    Reacts = 2,
     Results
 }
 
@@ -47,6 +48,7 @@ export type ServerChannel = {
     server_id: string;
     channel_id: string;
     result_channel_id: string;
+    channel_type: number;
 }
 
 export type QuestionResult = {
@@ -141,18 +143,29 @@ export const saveBonusDirect = (serverId: string, questionId: string, authorId: 
     insertBonusDirectCommand.run(serverId, questionId, authorId, userId, part, value, answerGiven ? encrypt(answerGiven, key) : null);
 }
 
-export const saveServerChannelsFromMessage = (collected: Collection<string, Message<boolean>>, server: Guild) => {
+export const saveAsyncServerChannelsFromMessage = (collected: Collection<string, Message<boolean>>, server: Guild) => {
     let tags = collected?.first()?.content.split(' ') || [];
 
-    deleteServerChannelsCommand.run(server.id);
-
     tags.forEach((tag) => {
-        const [_, channelId, resultsChannelId] = tag.match(/<#(\d+)>\/<#(\d+)>/) || [];
+        const [_, channelId, resultsChannelId] = tag.match(/<#(\d+)>\s*\/\s*<#(\d+)>/) || [];
         const channel = server.channels.cache.find((channel) => channel.id === channelId)?.id;
         const resultsChannel = server.channels.cache.find((channel) => channel.id === channelId)?.id;
 
         if (channel && resultsChannel) {
-            insertServerChannelCommand.run(server.id, channelId, resultsChannelId);
+            insertServerChannelCommand.run(server.id, channelId, resultsChannelId, 1);
+        }
+    });
+}
+
+export const saveBulkServerChannelsFromMessage = (collected: Collection<string, Message<boolean>>, server: Guild) => {
+    let tags = collected?.first()?.content.split(' ') || [];
+
+    tags.forEach((tag) => {
+        const [_, channelId] = tag.match(/<#(\d+)>/) || [];
+        const channel = server.channels.cache.find((channel) => channel.id === channelId)?.id;
+
+        if (channel) {
+            insertServerChannelCommand.run(server.id, channelId, "", 2);
         }
     });
 }
@@ -185,6 +198,12 @@ export const getThreadAndUpdateSummary = async (userProgress: UserProgress, thre
             autoArchiveDuration: 60
         });
         updateThreadId(userProgress.questionId, userProgress.type, thread.id);
+
+        try {
+            await thread.members.add(userProgress.authorId);
+        } catch (error) {
+            console.error(`Error adding member to thread: ${error}`);
+        }
 
         const buttonMessage = await playtestingChannel.messages.fetch(userProgress.buttonMessageId);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
-import { 
-    ActionRowBuilder, BaseMessageOptions, ButtonBuilder, ButtonStyle, Collection, EmbedBuilder, 
-    Guild, Message, MessageCreateOptions, MessageFlags, TextChannel 
+import {
+    ActionRowBuilder, BaseMessageOptions, ButtonBuilder, ButtonStyle, Collection, EmbedBuilder,
+    Guild, Message, MessageCreateOptions, MessageFlags, TextChannel
 } from "discord.js";
 import Database from 'better-sqlite3';
 import { encrypt } from "./crypto";
@@ -265,7 +265,7 @@ export const getToFirstIndicator = (clue:string) => {
     const thisIndex = words.findIndex(w => w.toLocaleLowerCase() === 'this' || w.toLocaleLowerCase() === 'these');
     const defaultSize = 30;
 
-    // if "this" or "these" is in the string and isn't the first word, 
+    // if "this" or "these" is in the string and isn't the first word,
     // truncate after first pronoun: https://github.com/JemCasey/playtesting-bot/issues/8
     if (thisIndex > 0) {
         const endIndex = thisIndex + 2;


### PR DESCRIPTION
This adds an `!r` command to allow the bot to auto-react with appropriate point amounts for playtesting purposes. Demo:

![image](https://github.com/user-attachments/assets/7157d8b2-6fe1-48c5-827a-c12a666600c1)

Aside: there's a bug in DiscordJS that prevents reacting with default emoji like 0️⃣, so I just uploaded duplicates of the relevant emoji to my version of the bot (Botero). If this is merged, then you'll have to add them to Botticelli/Bottesini too. I've attached them below.

[emojis.zip](https://github.com/user-attachments/files/17952532/emojis.zip)
