### PR TITLE
Improved emojis for bulk playtesting and summaries for async playtesting

### DIFF
--- a/src/handlers/buttonClickHandler.ts
+++ b/src/handlers/buttonClickHandler.ts
@@ -1,5 +1,5 @@
 import { Interaction } from "discord.js";
-import { BONUS_REGEX, TOSSUP_REGEX } from "src/constants";
+import { BONUS_DIFFICULTY_REGEX, BONUS_REGEX, TOSSUP_REGEX } from "src/constants";
 import { QuestionType, UserBonusProgress, UserProgress, UserTossupProgress, getEmbeddedMessage, getTossupParts, removeBonusValue, removeSpoilers } from "src/utils";
 
 export default async function handleButtonClick(interaction: Interaction, userProgress:  Map<string, UserProgress>, setUserProgress: (key: any, value: any) => void) {
@@ -15,7 +15,13 @@ export default async function handleButtonClick(interaction: Interaction, userPr
             if (userProgress.get(interaction.user.id)) {
                 await interaction.user.send(getEmbeddedMessage("You tried to start playtesting a question but have a different question reading in progress. Please complete that reading or type `x` to end it, then try again."));
             } else if (bonusMatch) {
-                const [_, leadin, part1, answer1, part2, answer2, part3, answer3] = bonusMatch;
+                const [_, leadin, part1, answer1, part2, answer2, part3, answer3, metadata, difficultyPart1, difficultyPart2, difficultyPart3] = bonusMatch;
+                const difficulty1Match = part1.match(BONUS_DIFFICULTY_REGEX) || [];
+                const difficulty2Match = part2.match(BONUS_DIFFICULTY_REGEX) || [];
+                const difficulty3Match = part3.match(BONUS_DIFFICULTY_REGEX) || [];
+                const difficulty1 = difficultyPart1 || difficulty1Match[1] || "e";
+                const difficulty2 = difficultyPart2 || difficulty2Match[1] || "m";
+                const difficulty3 = difficultyPart3 || difficulty3Match[1] || "h";
 
                 setUserProgress(interaction.user.id, {
                     type: QuestionType.Bonus,
@@ -29,6 +35,7 @@ export default async function handleButtonClick(interaction: Interaction, userPr
                     leadin,
                     parts: [part1, part2, part3],
                     answers: [answer1, answer2, answer3],
+                    difficulties: [difficulty1, difficulty2, difficulty3],
                     index: 0,
                     results: []
                 } as UserBonusProgress);

--- a/src/handlers/configHandler.ts
+++ b/src/handlers/configHandler.ts
@@ -8,6 +8,7 @@ export default async function handleConfig(message:Message<boolean>) {
     await msgChannel.send('First, configure the channels used for internal, asynchronous playtesting - where the results should be saved to a separate channel.');
     await msgChannel.send('List these channels in the form: `#playtesting-channel/#playtesting-results-channel #playtesting-channel-2/#playtesting-results-channel-2`.');
     await msgChannel.send('Make sure to add exactly one space between each set of playtesting and results channels. Note: Multiple playtesting channels can share a `playtesting-results-channel`.');
+    await msgChannel.send('To bypass asynchronous playtesting channels, type `#/#`.');
 
     try {
         let filter = (m: Message<boolean>) => m.author.id === message.author.id
@@ -26,6 +27,7 @@ export default async function handleConfig(message:Message<boolean>) {
         await msgChannel.send('Now, list the channels used for bulk playtesting - where playtesters will use reactions to indicate their results.');
         await msgChannel.send('List these channels in the form: `#playtesting-channel #playtesting-channel-2`.');
         await msgChannel.send('Do not repeat any channels from asynchronous playtesting. Make sure to add exactly one space between set of playtesting channels.');
+        await msgChannel.send('To bypass bulk playtesting channels, type `#/#`.');
 
         try {
             let filter = (m: Message<boolean>) => m.author.id === message.author.id

--- a/src/handlers/tossupHandler.ts
+++ b/src/handlers/tossupHandler.ts
@@ -58,11 +58,43 @@ export default async function handleTossupPlaytest(message: Message<boolean>, cl
         if (message.content.toLowerCase().startsWith('e'))
             await message.author.send(getSilentMessage(`ANSWER: ${removeSpoilers(userProgress.answer)}`));
 
+        var points_emoji_name = "";
+        var points_emoji;
         if (message.content.toLowerCase().startsWith('e')) {
-            resultMessage = `⭕ <@${message.author.id}>`;
+            points_emoji_name = "tossup_DNC";
         } else {
-            resultMessage = `${value > 0 ? "✅" : "❌"} <@${message.author.id}> @ "||${userProgress.questionParts[buzzIndex]}||"${note ? `; answer: "||${sanitizedNote}||"` : ''}`
-            + (userProgress.guesses?.length > 0 ? ` — was thinking \"${userProgress.guesses.map(g => `||${g.guess}|| @ clue #${g.index + 1}`).join(', ')}\"`: '');
+            if (value > 0) {
+                if (value === 15) {
+                    points_emoji_name = "tossup_15";
+                } else if (value === 10) {
+                    points_emoji_name = "tossup_10";
+                }
+            } else {
+                if (value === 0) {
+                    points_emoji_name = "tossup_DNC";
+                } else {
+                    points_emoji_name = "tossup_neg5";
+                }
+            }
+        }
+
+        await client.application?.emojis.fetch().then(function(emojis) {
+            try {
+                // console.log(`Searching for emoji: ${points_emoji_name}`);
+                points_emoji = emojis.find(emoji => emoji.name === points_emoji_name);
+                // console.log(`Found emoji: ${points_emoji}`);
+                if (points_emoji) {
+                    resultMessage += `${points_emoji}`;
+                }
+            } catch (error) {
+                console.error("One or more of the tossup points emojis failed to fetch:", error);
+            }
+        });
+
+        resultMessage += ` <@${message.author.id}>`;
+        if (!message.content.toLowerCase().startsWith('e')) {
+            resultMessage += ` @ "||${userProgress.questionParts[buzzIndex]}||"${note ? `; answer: "||${sanitizedNote}||"` : ''}`;
+            resultMessage += (userProgress.guesses?.length > 0 ? ` — was thinking \"${userProgress.guesses.map(g => `||${g.guess}|| @ clue #${g.index + 1}`).join(', ')}\"`: '');
         }
 
         while (countIndex-- > 0)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -74,6 +74,7 @@ export type UserBonusProgress = UserProgress & {
     leadin: string;
     parts: string[];
     answers: string[];
+    difficulties: string[];
     results: QuestionResult[];
 }
 
@@ -117,7 +118,7 @@ export const getSilentMessage = (message: string): MessageCreateOptions => {
     };
 }
 
-type BonusPart = {
+export type BonusPart = {
     part: number;
     answer: string;
     difficulty: nullableString;


### PR DESCRIPTION
New emojis created by @hftf to be uploaded to the Application Emojis menu: [playtesting_emojis.zip](https://github.com/user-attachments/files/18086391/playtesting_emojis.zip)

## Bulk Playtesting

Smart ordering of reacts based on bonus part difficulty:

![image](https://github.com/user-attachments/assets/f998e0de-83a5-4ebe-baf3-240764f49e04)

## Asynchronous Playtesting

Better emojis to summarize results for tossups:

![image](https://github.com/user-attachments/assets/2ea634c5-8a6d-4fcd-a203-22eeb1b5bb63)

Better emojis to summarize results for bonuses (again, with smart ordering):

![image](https://github.com/user-attachments/assets/6e5e27ec-6fab-4078-a3bd-dad98394455d)
